### PR TITLE
Fix for incorrect behavior when only bytes after buffer size are different.

### DIFF
--- a/cli/equalff.c
+++ b/cli/equalff.c
@@ -68,7 +68,7 @@ create_array_from_list(item *list_sentinel_head, size_t num_files) {
         if (i >= num_files) {
             fprintf(stderr, "Error: More items in list than files_count in create_array_from_list\n");
             // This indicates a discrepancy, possibly exit or handle error
-            exit(EXIT_FAILURE); 
+            exit(EXIT_FAILURE);
         }
         fis[i++] = current_node->fi;
         current_node = current_node->next;
@@ -160,7 +160,7 @@ static void cli_output_callback(const DuplicateSet *duplicates, void *user_data)
     CliAsyncCallbackLocalContext *local_ctx = (CliAsyncCallbackLocalContext *)user_data;
 
     // The original output format has a blank line before each new set of duplicates.
-    fprintf(stdout, "\n"); 
+    fprintf(stdout, "\n");
 
     for (int i = 0; i < duplicates->count; i++) {
         fprintf(stdout, "%s\n", duplicates->paths[i]);
@@ -173,10 +173,10 @@ static void cli_output_callback(const DuplicateSet *duplicates, void *user_data)
 
 int
 process_same_size_async(file_item *files[], int count, int max_buffer, int max_open_files) {
-    char **name = (char **) salloc(sizeof(char *) * count, NULL); 
+    char **name = (char **) salloc(sizeof(char *) * count, NULL);
     if (!name) {
         fprintf(stderr, "Error: Failed to allocate memory for file names in process_same_size_async.\n");
-        return 0; 
+        return 0;
     }
     for (int i = 0; i < count; i++) {
         name[i] = files[i]->filepath;
@@ -185,13 +185,13 @@ process_same_size_async(file_item *files[], int count, int max_buffer, int max_o
     CliAsyncCallbackLocalContext local_cb_ctx = {0};
     char *error_msg = NULL;
 
-    int ret_code = compare_files_async(name, count, max_buffer, max_open_files, 
+    int ret_code = compare_files_async(name, count, max_buffer, max_open_files,
                                        cli_output_callback, &local_cb_ctx, &error_msg);
-    free(name); 
+    free(name);
 
     if (ret_code != 0) {
         fprintf(stderr, "Error during file comparison: %s (Code: %d)\n",
-                error_msg ? error_msg : strerror(ret_code), 
+                error_msg ? error_msg : strerror(ret_code),
                 ret_code);
         if (error_msg) {
             free_error_message(error_msg);
@@ -263,18 +263,18 @@ process_files_array(file_item **fis, size_t num_files_in_array, int max_buffer, 
 
     cli_global_first_output_emitted = 0; // Reset for this processing run
     int stat_cluster_count = 0;
-    
+
     size_t current_idx = 0;
     while (current_idx < num_files_in_array) {
         size_t group_start_idx = current_idx;
         long long current_group_file_size = fis[group_start_idx]->st_size;
 
         // Advance current_idx to find the end of the current group of same-sized files
-        current_idx++; 
+        current_idx++;
         while (current_idx < num_files_in_array && fis[current_idx]->st_size == current_group_file_size) {
             current_idx++;
         }
-        
+
         int count_in_this_group = current_idx - group_start_idx;
 
         if (count_in_this_group > 1) {
@@ -284,7 +284,7 @@ process_files_array(file_item **fis, size_t num_files_in_array, int max_buffer, 
                 print_files(&fis[group_start_idx], count_in_this_group);
                 stat_cluster_count++;
                 if(count_in_this_group > 0) cli_global_first_output_emitted = 1; // Mark output occurred
-            } 
+            }
             // For non-zero sized files that meet min_file_size criteria
             else if (current_group_file_size > 0 && current_group_file_size >= min_file_size) {
                 stat_cluster_count += process_same_size_async(&fis[group_start_idx], count_in_this_group, max_buffer, max_open_files);
@@ -317,7 +317,7 @@ process_folders(int folders_cnt,
                 int opt_same_fs,
                 int opt_follow_symlinks,
                 int opt_buffer_size, int opt_max_open_files, int opt_min_file_size) {
-    
+
     // Initialize the global file collection context
     g_file_collection.list_head = (item *) salloc(sizeof(item), handle_exit);
     g_file_collection.list_head->fi = NULL;    // Sentinel node has no file_item
@@ -347,7 +347,7 @@ process_folders(int folders_cnt,
         fprintf(stderr, "%zu files found\nSorting ... ", g_file_collection.files_count);
 
         file_item **fis = create_array_from_list(g_file_collection.list_head, g_file_collection.files_count);
-        
+
         process_files_array(fis, g_file_collection.files_count, opt_buffer_size, opt_max_open_files, opt_min_file_size);
 
         // Cleanup sequence:
@@ -357,7 +357,7 @@ process_folders(int folders_cnt,
         free(fis);
         // 3. Free the linked list nodes (item structs)
         free_file_list_nodes(g_file_collection.list_head);
-        
+
         // Reset global context pointers for safety, though not strictly necessary if program exits soon
         g_file_collection.list_head = NULL;
         g_file_collection.list_tail = NULL;

--- a/lib/cmpdata.c
+++ b/lib/cmpdata.c
@@ -54,14 +54,14 @@ cmp_init(cmpdata *cd, int size, size_t max_buffer) {
         return EINVAL; // Invalid argument for buffer size
     }
 
-    cd->buffer_size = (max_buffer == 0 || ( (size_t)size > 0 && max_buffer / (size_t)size > BUFFER_SIZE) ) 
-                      ? BUFFER_SIZE 
+    cd->buffer_size = (max_buffer == 0 || ( (size_t)size > 0 && max_buffer / (size_t)size > BUFFER_SIZE) )
+                      ? BUFFER_SIZE
                       : max_buffer / (size_t)size;
     if (cd->buffer_size < MIN_BUFFER_PER_FILE) {
         cd->buffer_size = MIN_BUFFER_PER_FILE;
     }
     if (size > 0 && cd->buffer_size == 0) { // Avoid zero buffer size if size > 0
-        cd->buffer_size = MIN_BUFFER_PER_FILE; 
+        cd->buffer_size = MIN_BUFFER_PER_FILE;
     }
 
 

--- a/lib/fcompare.c
+++ b/lib/fcompare.c
@@ -388,7 +388,7 @@ int compare_files_async(
                     effective_read_for_batch = min_positive_read_in_batch;
                     overall_data_read_in_pass += effective_read_for_batch;
                 }
-
+                cmp_uf_reset_ordered(&current_cmp_data, group_start_idx_in_order_array, group_size);
                 current_cmp_data.readed = effective_read_for_batch;
 
                 if (group_size > 1) {

--- a/lib/fcompare.c
+++ b/lib/fcompare.c
@@ -22,24 +22,24 @@ static void compare_files_adapter_callback(const DuplicateSet *duplicates_from_a
 
     DuplicateSet *new_sets_ptr = (DuplicateSet *)realloc(result->sets, (result->count + 1) * sizeof(DuplicateSet));
     if (!new_sets_ptr) {
-        if (result->error_message == NULL) { 
+        if (result->error_message == NULL) {
             result->error_message = sstrdup("Adapter: Failed to reallocate memory for duplicate sets array.", NULL);
             // If sstrdup itself fails for the error message, we can't do much more here for the message.
         }
         result->error_code = ENOMEM;
-        return; 
+        return;
     }
     result->sets = new_sets_ptr;
     DuplicateSet *current_target_set = &result->sets[result->count];
-    current_target_set->paths = NULL; 
-    current_target_set->count = 0;    
+    current_target_set->paths = NULL;
+    current_target_set->count = 0;
 
     current_target_set->paths = (char **)salloc((duplicates_from_async->count) * sizeof(char *), NULL); // Pass NULL for error_handle
     if (!current_target_set->paths) {
-        if (result->error_message == NULL) { 
+        if (result->error_message == NULL) {
             result->error_message = sstrdup("Adapter: Failed to salloc paths for set.", NULL);
         }
-        result->error_code = ENOMEM; 
+        result->error_code = ENOMEM;
         return;
     }
 
@@ -61,7 +61,7 @@ static void compare_files_adapter_callback(const DuplicateSet *duplicates_from_a
         paths_copied++;
     }
     current_target_set->count = paths_copied;
-    result->count++; 
+    result->count++;
 }
 
 // No longer needed here as it's defined above
@@ -89,14 +89,14 @@ ufsorter(const void *p1, const void *p2, void *arg)
     cmpdata *cd = (cmpdata *) arg;
 
     if (f1_idx < 0 || f1_idx >= cd->size || f2_idx < 0 || f2_idx >= cd->size) {
-        return 0; 
+        return 0;
     }
 
     int f1_struct_null = (cd->file[f1_idx] == NULL);
     int f2_struct_null = (cd->file[f2_idx] == NULL);
 
     if (f1_struct_null && f2_struct_null) {
-        cmp_uf_diff(cd, f1_idx, f2_idx); 
+        cmp_uf_diff(cd, f1_idx, f2_idx);
         return 0;
     }
     if (f1_struct_null || f2_struct_null) {
@@ -104,7 +104,7 @@ ufsorter(const void *p1, const void *p2, void *arg)
         return f1_struct_null ? -1 : 1;
     }
 
-    int f1_open_failed = (cd->file[f1_idx]->fd == NULL && cd->file[f1_idx]->_errno != 0); 
+    int f1_open_failed = (cd->file[f1_idx]->fd == NULL && cd->file[f1_idx]->_errno != 0);
     int f2_open_failed = (cd->file[f2_idx]->fd == NULL && cd->file[f2_idx]->_errno != 0);
 
     if (f1_open_failed && f2_open_failed) {
@@ -115,20 +115,20 @@ ufsorter(const void *p1, const void *p2, void *arg)
         cmp_uf_diff(cd, f1_idx, f2_idx);
         return f1_open_failed ? -1 : 1;
     }
-    
+
     int f1_has_read_error = (cd->file[f1_idx]->_errno != 0 && (cd->file[f1_idx]->fd == NULL || !feof(cd->file[f1_idx]->fd)) );
     int f2_has_read_error = (cd->file[f2_idx]->_errno != 0 && (cd->file[f2_idx]->fd == NULL || !feof(cd->file[f2_idx]->fd)) );
 
     if (f1_has_read_error && f2_has_read_error) {
         cmp_uf_diff(cd, f1_idx, f2_idx);
-        return 0; 
+        return 0;
     }
     if (f1_has_read_error || f2_has_read_error) {
         cmp_uf_diff(cd, f1_idx, f2_idx);
-        return f1_has_read_error ? -1 : 1; 
+        return f1_has_read_error ? -1 : 1;
     }
-    
-    if (cd->readed == 0) { 
+
+    if (cd->readed == 0) {
         cmp_uf_union(cd, f1_idx, f2_idx);
         return 0;
     }
@@ -149,16 +149,16 @@ compare_files(char *name[], int count, int max_buffer, int max_open_files) {
     if (!result) {
         // salloc failed for the main result structure. Cannot set error message in it.
         // Consider logging to stderr or having a global error state if this is critical.
-        return NULL; 
+        return NULL;
     }
 
     result->sets = NULL;
     result->count = 0;
     result->error_code = 0;
-    result->error_message = NULL; 
+    result->error_message = NULL;
 
     if (count < 2) {
-        return result; 
+        return result;
     }
 
     struct CompareFilesAsyncAdapterContext adapter_ctx;
@@ -176,7 +176,7 @@ compare_files(char *name[], int count, int max_buffer, int max_open_files) {
     );
 
     if (async_ret_code != 0) {
-        if (result->error_code == 0) { 
+        if (result->error_code == 0) {
             result->error_code = async_ret_code;
             if (async_error_msg) {
                 if (result->error_message == NULL) {
@@ -218,7 +218,7 @@ void free_comparison_result(ComparisonResult *result) {
         for (int i = 0; i < result->count; i++) {
             if (result->sets[i].paths) {
                 for (int j = 0; j < result->sets[i].count; j++) {
-                    if (result->sets[i].paths[j]) { 
+                    if (result->sets[i].paths[j]) {
                         free(result->sets[i].paths[j]);
                     }
                 }
@@ -257,29 +257,29 @@ int compare_files_async(
     if (count < 0 || (count > 0 && file_paths == NULL) || max_buffer_per_file <= 0 || callback == NULL) {
         if (error_message_out) {
             *error_message_out = sstrdup("Invalid arguments (NULL file_paths, count < 0, zero/negative max_buffer, or NULL callback).", NULL);
-            if (*error_message_out == NULL) return ENOMEM; 
+            if (*error_message_out == NULL) return ENOMEM;
         }
         return EINVAL;
     }
-    
+
     if (count < 2) {
-        return 0; 
+        return 0;
     }
 
     char *local_error_message = NULL;
     int local_error_code = 0;
 
     fmanage *fm = (fmanage *) salloc(sizeof(fmanage), NULL);
-    if (!fm) { 
-        local_error_message = sstrdup("Failed to allocate fmanage structure.", NULL); 
-        local_error_code = ENOMEM; 
+    if (!fm) {
+        local_error_message = sstrdup("Failed to allocate fmanage structure.", NULL);
+        local_error_code = ENOMEM;
         if (error_message_out) *error_message_out = local_error_message;
         else if (local_error_message) free(local_error_message);
         return local_error_code;
     }
     fm_init(fm, max_open_files > 0 ? max_open_files : count);
 
-    cmpdata current_cmp_data; 
+    cmpdata current_cmp_data;
     int cmp_init_ret = cmp_init(&current_cmp_data, count, max_buffer_per_file);
 
     if (cmp_init_ret != 0) {
@@ -292,12 +292,12 @@ int compare_files_async(
         } else {
              local_error_message = sstrdup("Unknown error during comparison data initialization.", NULL);
         }
-        cmp_free(&current_cmp_data); 
+        cmp_free(&current_cmp_data);
         if (error_message_out) *error_message_out = local_error_message;
         else if (local_error_message) free(local_error_message);
         return local_error_code;
     }
-    
+
     int overall_data_read_in_pass;
     do {
         overall_data_read_in_pass = 0;
@@ -313,16 +313,16 @@ int compare_files_async(
             }
 
             if (group_size > 1) {
-                size_t min_positive_read_in_batch = (size_t)-1; 
+                size_t min_positive_read_in_batch = (size_t)-1;
                 int any_positive_data_read = 0;
 
                 for (int i = 0; i < group_size; i++) {
                     int original_file_index = current_cmp_data.order[group_start_idx_in_order_array + i];
-                    
+
                     if (current_cmp_data.file[original_file_index] == NULL) {
                         current_cmp_data.file[original_file_index] = fm_fopen(fm, file_paths[original_file_index]);
                         if (current_cmp_data.file[original_file_index] == NULL) {
-                            if (local_error_code == 0) { 
+                            if (local_error_code == 0) {
                                 local_error_code = errno;
                                 char err_buf[256];
                                 if (snprintf(err_buf, sizeof(err_buf), "Cannot open file '%s': %s", file_paths[original_file_index], strerror(errno)) > 0) {
@@ -335,7 +335,7 @@ int compare_files_async(
                                 if (!local_error_message && local_error_code != 0 && local_error_code != ENOMEM) { /* sstrdup failed, but local_error_code is already errno */ }
                                 else if (!local_error_message) { local_error_code = ENOMEM; }
                             }
-                            continue; 
+                            continue;
                         }
                     }
 
@@ -348,7 +348,7 @@ int compare_files_async(
                             if (bytes_read_this_file < min_positive_read_in_batch) {
                                 min_positive_read_in_batch = bytes_read_this_file;
                             }
-                        } else { 
+                        } else {
                             if (current_cmp_data.file[original_file_index]->_errno != 0) {
                                 if (local_error_code == 0) {
                                     local_error_code = current_cmp_data.file[original_file_index]->_errno;
@@ -365,8 +365,8 @@ int compare_files_async(
                                 }
                             }
                         }
-                    } else { 
-                        if (local_error_code == 0 && current_cmp_data.file[original_file_index] != NULL ) { 
+                    } else {
+                        if (local_error_code == 0 && current_cmp_data.file[original_file_index] != NULL ) {
                            // Capture pre-existing error if no other error has been captured yet.
                            local_error_code = current_cmp_data.file[original_file_index]->_errno;
                            char err_buf[256];
@@ -381,17 +381,17 @@ int compare_files_async(
                            else if (!local_error_message) { local_error_code = ENOMEM; }
                         }
                     }
-                } 
+                }
 
                 size_t effective_read_for_batch = 0;
                 if (any_positive_data_read) {
                     effective_read_for_batch = min_positive_read_in_batch;
-                    overall_data_read_in_pass += effective_read_for_batch; 
+                    overall_data_read_in_pass += effective_read_for_batch;
                 }
-                
+
                 current_cmp_data.readed = effective_read_for_batch;
 
-                if (group_size > 1) { 
+                if (group_size > 1) {
                     #if defined(_WIN32) || defined(_WIN64)
                         // Windows: use qsort_s. The context argument is last, similar to GNU qsort_r.
                         // errno_t qsort_s(void *base, rsize_t nmemb, rsize_t size, int (*compar)(const void *k1, const void *k2, void *context), void *context);
@@ -405,16 +405,16 @@ int compare_files_async(
                         qsort_r(&current_cmp_data.order[group_start_idx_in_order_array], group_size, sizeof(int), ufsorter, &current_cmp_data);
                     #endif
                 }
-            } 
-        } 
+            }
+        }
     } while (overall_data_read_in_pass > 0);
 
-    if (local_error_code == 0) { 
+    if (local_error_code == 0) {
         int current_idx_in_order = 0;
         while (current_idx_in_order < count) {
-            int group_start_sidx = current_idx_in_order; 
+            int group_start_sidx = current_idx_in_order;
             current_idx_in_order++;
-            while (current_idx_in_order < count && 
+            while (current_idx_in_order < count &&
                    cmp_uf_ordered_same(&current_cmp_data, group_start_sidx, current_idx_in_order)) {
                 current_idx_in_order++;
             }
@@ -423,40 +423,40 @@ int compare_files_async(
             if (num_in_potential_group > 1) {
                 DuplicateSet current_set;
                 current_set.paths = (char **)salloc(num_in_potential_group * sizeof(char *), NULL); // Pass NULL
-                
+
                 if (!current_set.paths) {
                     if (!local_error_message) local_error_message = sstrdup("Failed to allocate paths for a duplicate set callback.", NULL);
                     if (!local_error_code) local_error_code = ENOMEM;
-                    break; 
+                    break;
                 }
 
                 int actual_paths_added = 0;
                 for (int k = 0; k < num_in_potential_group; ++k) {
                     int original_file_idx = current_cmp_data.order[group_start_sidx + k];
-                    
-                    if (current_cmp_data.file[original_file_idx] != NULL && 
+
+                    if (current_cmp_data.file[original_file_idx] != NULL &&
                         current_cmp_data.file[original_file_idx]->_errno == 0) {
-                        
+
                         current_set.paths[actual_paths_added] = sstrdup(file_paths[original_file_idx], NULL); // Pass NULL
                         if (!current_set.paths[actual_paths_added]) {
                              if (!local_error_message) local_error_message = sstrdup("Failed to sstrdup file path for callback.", NULL);
                              if (!local_error_code) local_error_code = ENOMEM;
                              for(int j=0; j < actual_paths_added; ++j) free(current_set.paths[j]);
                              free(current_set.paths);
-                             current_set.paths = NULL; 
-                             goto cleanup_after_callback_error; 
+                             current_set.paths = NULL;
+                             goto cleanup_after_callback_error;
                         }
                         actual_paths_added++;
                     }
                 }
-                
-                if (actual_paths_added > 1) { 
+
+                if (actual_paths_added > 1) {
                     current_set.count = actual_paths_added;
                     if (actual_paths_added < num_in_potential_group && actual_paths_added > 0) {
                         char **shrunk_paths = (char **)realloc(current_set.paths, actual_paths_added * sizeof(char *));
                         if (shrunk_paths) {
                             current_set.paths = shrunk_paths;
-                        } 
+                        }
                     }
                     callback(&current_set, user_data);
                 }
@@ -479,14 +479,14 @@ cleanup_after_callback_error:;
         }
     }
     cmp_free(&current_cmp_data);
-    fm_free(fm); 
-    free(fm);    
+    fm_free(fm);
+    free(fm);
 
     if (error_message_out && local_error_message) {
-        *error_message_out = local_error_message; 
+        *error_message_out = local_error_message;
     } else if (local_error_message) {
-        free(local_error_message); 
+        free(local_error_message);
     }
-    
+
     return local_error_code;
 }

--- a/lib/fmanage.c
+++ b/lib/fmanage.c
@@ -122,7 +122,7 @@ fm_fopen(fmanage *fm, char *filename) {
                 if (errno != EMFILE) {
                     // For other errors (e.g. ENOENT), return NULL immediately to signal to caller
                     // The caller (compare_files) will then use the current errno value.
-                    return NULL;    
+                    return NULL;
                 }
                 // If EMFILE, loop will continue to try closing other files
             }
@@ -163,7 +163,7 @@ fm_fread(fmanage *fm, void *ptr, size_t size, size_t nmemb, fm_FILE *ff) {
 
         errno = 0; // Clear errno before calling fread
         size_t cnt = fread(ptr, size, nmemb, ff->fd);
-        // After fread, errno is set ONLY IF an error occurred. 
+        // After fread, errno is set ONLY IF an error occurred.
         // If EOF, feof(ff->fd) is true. If error, ferror(ff->fd) is true.
 
         // Store errno only if a read error actually occurred.
@@ -176,7 +176,7 @@ fm_fread(fmanage *fm, void *ptr, size_t size, size_t nmemb, fm_FILE *ff) {
             // If it was EOF, ff->_errno should remain 0 for this path.
             if (ff->_errno == 0) { // If no prior error on this fm_FILE struct
                  // do not set ff->_errno from global errno here if it was just EOF
-            } 
+            }
         }
         // The old code: ff->_errno = errno; was too broad.
         // It should be: if (ferror(ff->fd)) ff->_errno = errno; else if successful open ff->_errno = 0 for read;

--- a/test_harness.c
+++ b/test_harness.c
@@ -4,7 +4,7 @@
 #include <errno.h> // For checking errno values like ENOMEM, EINVAL
 
 // Assuming fcompare.h is accessible via -I./lib
-#include "fcompare.h" 
+#include "fcompare.h"
 
 // Structure to hold results from async callback for verification
 typedef struct {
@@ -42,6 +42,21 @@ void create_dummy_file(const char *filename, const char *content) {
         perror("Failed to create dummy file");
     }
 }
+
+void create_dummy_file_with_size(const char *filename, const char *content, int size) {
+    FILE *fp = fopen(filename, "w");
+    if (fp) {
+        fputs(content, fp);
+        size_t ret =fwrite(content, size, 1,fp);
+        if (ret < 1) {
+            perror("Error create dummy file");
+        }
+        fclose(fp);
+    } else {
+        perror("Failed to create dummy file");
+    }
+}
+
 
 void print_result(ComparisonResult *result, const char* test_name) {
     printf("--- Test: %s ---\n", test_name);
@@ -121,11 +136,11 @@ int main() {
     create_dummy_file("test7_fileA.txt", "Small buffer test");
     create_dummy_file("test7_fileB.txt", "Small buffer test");
     char *test7_files[] = {"test7_fileA.txt", "test7_fileB.txt"};
-    result = compare_files(test7_files, 2, 200, 10); 
+    result = compare_files(test7_files, 2, 200, 10);
     print_result(result, "Buffer too small (expect EINVAL from cmp_init)");
     remove("test7_fileA.txt");
     remove("test7_fileB.txt");
-    
+
     // --- Test Case 8: Corrected - Only same-sized (empty) files passed to compare_files
     create_dummy_file("test8_fileA.txt", "");
     create_dummy_file("test8_fileB.txt", "");
@@ -140,7 +155,7 @@ int main() {
     // If the non-empty is shorter than buffer, and empty is first, readed=0, they'd be unioned by current ufsorter.
     // This highlights that compare_files *expects files of same size*.
     // For the harness, let's ensure they are treated as different if passed together.
-    create_dummy_file("test9_fileA.txt", ""); 
+    create_dummy_file("test9_fileA.txt", "");
     create_dummy_file("test9_fileB.txt", "not empty");
     char *test9_files[] = {"test9_fileA.txt", "test9_fileB.txt"};
     result = compare_files(test9_files, 2, 1024*1024, 10);
@@ -154,7 +169,7 @@ int main() {
     create_dummy_file("test10_fileB.txt", "Async Different Content");
     create_dummy_file("test10_fileC.txt", "Async Hello World");
     char *test10_files[] = {"test10_fileA.txt", "test10_fileB.txt", "test10_fileC.txt"};
-    
+
     AsyncTestContext async_ctx_10 = {0, 0};
     char *error_msg_10 = NULL;
     int ret_10 = compare_files_async(test10_files, 3, 1024 * 1024, 10, async_test_callback, &async_ctx_10, &error_msg_10);
@@ -181,7 +196,7 @@ int main() {
     create_dummy_file("test11_fileA.txt", "Async Alpha");
     create_dummy_file("test11_fileB.txt", "Async Beta");
     char *test11_files[] = {"test11_fileA.txt", "test11_fileB.txt"};
-    
+
     AsyncTestContext async_ctx_11 = {0, 0};
     char *error_msg_11 = NULL;
     int ret_11 = compare_files_async(test11_files, 2, 1024 * 1024, 10, async_test_callback, &async_ctx_11, &error_msg_11);
@@ -221,6 +236,112 @@ int main() {
         printf("ERROR: compare_files_async completed successfully but was expected to fail. Sets found: %d\n", async_ctx_12.sets_found);
         printf("Verification: FAILED (Error was expected)\n");
     }
+    printf("--------------------\n\n");
+
+    char * payload = malloc(8193);
+    memset(payload, 0, 8193);
+    create_dummy_file_with_size("test1_fileA.txt", payload, 8193);
+    create_dummy_file_with_size("test1_fileB.txt", payload, 8193);
+    create_dummy_file_with_size("test1_fileC.txt", payload, 8193);
+    char *test13_files[] = {"test1_fileA.txt", "test1_fileB.txt", "test1_fileC.txt"};
+    result = compare_files(test13_files, 3, 1024 * 1024, 10);
+    printf("--- Test: %s ---\n", "Three identical");
+    remove("test1_fileA.txt");
+    remove("test1_fileB.txt");
+    remove("test1_fileC.txt");
+    free(payload);
+    if (!result) {
+        printf("ERROR : NULL returned\n");
+    } else {
+        // Basic verification
+        if (result->count == 1 && result->sets->count == 3) {
+            printf("Verification: PASSED (1 set of 2 files found)\n");
+        } else {
+            printf("Verification: FAILED (Expected 1 set of 3 files, got %d sets, %d total files)\n",  result->count, result->sets->count);
+        }
+        printf("Found %d duplicate set(s).\n", result->count);
+        for (int i = 0; i < result->count; i++) {
+            printf("  Set %d:\n", i + 1);
+            for (int j = 0; j < result->sets[i].count; j++) {
+                printf("    - %s\n", result->sets[i].paths[j]);
+            }
+        }
+
+    }
+    free_comparison_result(result);
+    result = NULL;
+    printf("--------------------\n\n");
+
+    int psize = 1024;
+    payload = malloc(psize);
+    memset(payload, 'a', psize);
+    create_dummy_file_with_size("test1_fileA.txt", payload, psize);
+    create_dummy_file_with_size("test1_fileB.txt", payload, psize);
+    payload[psize-1] = 'b';
+    create_dummy_file_with_size("test1_fileC.txt", payload, psize);
+    char *test14_files[] = {"test1_fileA.txt", "test1_fileB.txt", "test1_fileC.txt"};
+    result = compare_files(test14_files, 3, 1024, 10);
+    printf("--- Test: %s ---\n", "Two identical(1k), One different");
+    remove("test1_fileA.txt");
+    remove("test1_fileB.txt");
+    remove("test1_fileC.txt");
+    free(payload);
+    if (!result) {
+        printf("ERROR : NULL returned\n");
+    } else {
+        // Basic verification
+        if (result->count == 1 && result->sets->count == 2) {
+            printf("Verification: PASSED (1 set of 2 files found)\n");
+        } else {
+            printf("Verification: FAILED (Expected 1 set of 2 files, got %d sets, %d total files)\n",  result->count, result->sets->count);
+        }
+        printf("Found %d duplicate set(s).\n", result->count);
+        for (int i = 0; i < result->count; i++) {
+            printf("  Set %d:\n", i + 1);
+            for (int j = 0; j < result->sets[i].count; j++) {
+                printf("    - %s\n", result->sets[i].paths[j]);
+            }
+        }
+
+    }
+    free_comparison_result(result);
+    result = NULL;
+    printf("--------------------\n\n");
+
+    psize = 1025;
+    payload = malloc(psize);
+    memset(payload, 'a', psize);
+    create_dummy_file_with_size("test1_fileA.txt", payload, psize);
+    create_dummy_file_with_size("test1_fileB.txt", payload, psize);
+    payload[psize-1] = 'b';
+    create_dummy_file_with_size("test1_fileC.txt", payload, psize);
+    char *test15_files[] = {"test1_fileA.txt", "test1_fileB.txt", "test1_fileC.txt"};
+    result = compare_files(test15_files, 3, 1024, 10);
+    printf("--- Test: %s ---\n", "Two identical(4k), One different");
+    remove("test1_fileA.txt");
+    remove("test1_fileB.txt");
+    remove("test1_fileC.txt");
+    free(payload);
+    if (!result) {
+        printf("ERROR : NULL returned\n");
+    } else {
+        // Basic verification
+        if (result->count == 1 && result->sets->count == 2) {
+            printf("Verification: PASSED (1 set of 2 files found)\n");
+        } else {
+            printf("Verification: FAILED (Expected 1 set of 2 files, got %d sets, %d total files)\n",  result->count, result->sets->count);
+        }
+        printf("Found %d duplicate set(s).\n", result->count);
+        for (int i = 0; i < result->count; i++) {
+            printf("  Set %d:\n", i + 1);
+            for (int j = 0; j < result->sets[i].count; j++) {
+                printf("    - %s\n", result->sets[i].paths[j]);
+            }
+        }
+
+    }
+    free_comparison_result(result);
+    result = NULL;
     printf("--------------------\n\n");
 
     printf("All tests finished.\n");


### PR DESCRIPTION
Say there are 2 files, each of size 8193 bytes and only the last byte is different between them.
The default buffer size is 8192.

Current code is incorrectly flagging these 2 files as equal.
Added a test case, and fix for the same.

(Also added a separate commit stripping the trailing whitespace)